### PR TITLE
Use atom-text-editor tag instead of editor class

### DIFF
--- a/styles/slim.less
+++ b/styles/slim.less
@@ -23,7 +23,7 @@ atom-workspace atom-panel-container.left:empty {
 }
 
 // Style the theme to be a bit more sleek
-.editor, atom-text-editor::shadow {
+atom-text-editor::shadow {
     background-color: #202020;
     font-weight: 500;
     // Make comments normal instead of italic


### PR DESCRIPTION
This should fix a deprecation warning with Atom 1.0
